### PR TITLE
Handle PHPUnit names when running from phar

### DIFF
--- a/src/Namers/PHPUnitNamer.php
+++ b/src/Namers/PHPUnitNamer.php
@@ -23,13 +23,20 @@ class PHPUnitNamer implements Namer
 
     public static function isPHPUnitTest($path)
     {
-        $expectedPath =
-            DIRECTORY_SEPARATOR . 'phpunit'
-            . DIRECTORY_SEPARATOR . 'src'
-            . DIRECTORY_SEPARATOR . 'Framework'
-            . DIRECTORY_SEPARATOR . 'TestCase.php';
-        $pathPart = substr($path, -strlen($expectedPath));
-        return $pathPart === $expectedPath;
+        $expectedLocalPath = implode(DIRECTORY_SEPARATOR, ['', 'phpunit', 'src', 'Framework', 'TestCase.php']);
+        $expectedPharPath = implode('/', ['', 'phpunit', 'Framework', 'TestCase.php']);
+        return self::endsWith($path, $expectedLocalPath) || self::endsWith($path, $expectedPharPath);
+    }
+
+    private static function endsWith($haystack, $needle)
+    {
+        // https://stackoverflow.com/a/834355/25507
+        $length = strlen($needle);
+        if ($length == 0) {
+            return true;
+        }
+
+        return substr($haystack, -$length) === $needle;
     }
 
     public function getApprovedFile($extensionWithoutDot)


### PR DESCRIPTION
When using a phar version of PHPUnit, the file names look like `phar://path/to/phpunit/phpunit/Framework/TestCase.php` instead of using the native OS's directory separator. This PR updates `isPHPUnitTest` to handle this case.